### PR TITLE
Replace callcode with delegatecall

### DIFF
--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
@@ -42,7 +42,7 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
         bytes memory callData = abi.encodeWithSelector(BLOCK_REWARD_CONTRACT_SELECTOR);
 
         assembly {
-            let result := callcode(gas, feeManager, 0x0, add(callData, 0x20), mload(callData), 0, 32)
+            let result := delegatecall(gas, feeManager, add(callData, 0x20), mload(callData), 0, 32)
 
             if and(eq(returndatasize, 32), result) {
                 blockReward := mload(0)

--- a/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/RewardableHomeBridgeErcToNative.sol
@@ -37,6 +37,12 @@ contract RewardableHomeBridgeErcToNative is RewardableBridge {
         bytes memory callData = abi.encodeWithSelector(GET_AMOUNT_TO_BURN, _value);
         address feeManager = feeManagerContract();
         assembly {
+            // Note: callcode is deprecated and has the wrong msg.sender - changing to delegatecall here
+            // reverts, but it's not essential because the getAmountToBurn function in BaseFeeManager
+            // does not use this value. Furthermore this bridge mode is not deployed or used in the
+            // cardstack bridge at all, and is only used in the test suite
+            // If upgrading solidity to > 0.5, delegatecall returns a value without assembly so this
+            // construction is uncessessary
             let result := callcode(gas, feeManager, 0x0, add(callData, 0x20), mload(callData), 0, 32)
 
             switch and(eq(returndatasize, 32), result)


### PR DESCRIPTION
callcode(), an early precursor to delegatecall(), has been deprecated since the latter’s introduction, on account of the original design not properly preserving the values of msg.sender and msg.value. Using callcode() instead of delegatecall() can thus result in unexpected behavior if the called function evaluates either msg.sender or msg.value.

CS-2878